### PR TITLE
Remove podcast string from move_file.py

### DIFF
--- a/move_file.py
+++ b/move_file.py
@@ -9,51 +9,49 @@ import helper
 
 
 def _MoveFileOverImpl(
-    podcast: str,
-    file: pathlib.Path,
-    destination: pathlib.Path,
-    archive_folder: pathlib.Path,
+    file_source: pathlib.Path,
+    file_destination: pathlib.Path,
+    archive_destination: pathlib.Path,
     title_prefix: str,
     speed: float,
     dry_run: bool,
 ) -> None:
     # Make copies of important episodes.
-    if archive_folder:
+    if archive_destination:
         if dry_run:
-            print("Dry run, would have archived %s" % (file))
+            print("Dry run, would have archived %s" % (file_source))
         else:
-            podcast_archive_folder = pathlib.Path(archive_folder, podcast)
-            os.makedirs(podcast_archive_folder, exist_ok=True)
-            filename = file.name
-            archive_destination = pathlib.Path(podcast_archive_folder, filename)
-            print("Making copy of %s in archive (%s)" % (filename, archive_destination))
-            shutil.copyfile(file, archive_destination)
+            os.makedirs(archive_destination.parent, exist_ok=True)
+            print(
+                "Making copy of %s in archive (%s)"
+                % (file_source.name, archive_destination)
+            )
+            shutil.copyfile(file_source, archive_destination)
 
-    dest = pathlib.Path(destination, file.name)
-    album = file.parent.name
+    album = file_source.parent.name
     if dry_run:
-        print("Dry run, would have moved %s to %s" % (file, dest))
+        print("Dry run, would have moved %s to %s" % (file_source, file_destination))
         print("With album %s" % album)
     else:
-        helper.PrepareAudioAndMove(file, dest, album, title_prefix, speed)
+        helper.PrepareAudioAndMove(
+            file_source, file_destination, album, title_prefix, speed
+        )
 
 
 def main(args: typing.Optional[typing.List[str]]) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--podcast-show-name", type=str, required=True)
     parser.add_argument("--file-path", type=pathlib.Path, required=True)
-    parser.add_argument("--destination", type=pathlib.Path, required=True)
-    parser.add_argument("--archive-folder", type=pathlib.Path, default=None)
+    parser.add_argument("--file-destination", type=pathlib.Path, required=True)
+    parser.add_argument("--archive-destination", type=pathlib.Path, default=None)
     parser.add_argument("--title-prefix", type=str, default="")
     parser.add_argument("--speed", type=float, default=1.0)
     parser.add_argument("--dry-run", action="store_true", default=False)
     parsed_args = parser.parse_args(args)
 
     _MoveFileOverImpl(
-        parsed_args.podcast_show_name,
         parsed_args.file_path,
-        parsed_args.destination,
-        parsed_args.archive_folder,
+        parsed_args.file_destination,
+        parsed_args.archive_destination,
         parsed_args.title_prefix,
         parsed_args.speed,
         parsed_args.dry_run,

--- a/move_file_test.py
+++ b/move_file_test.py
@@ -11,8 +11,6 @@ class TestMoveFile(unittest.TestCase):
     def setUp(self) -> None:
         self.holding_dir = tempfile.TemporaryDirectory()
 
-        self.podcast_show_name = "podcast_show"
-
         test_file_source = os.path.join(
             test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE
         )
@@ -30,7 +28,7 @@ class TestMoveFile(unittest.TestCase):
             self.destination, os.path.basename(self.podcast_file)
         )
         self.archived_podcast_path = os.path.join(
-            self.archive, self.podcast_show_name, os.path.basename(self.podcast_file)
+            self.archive, "fake_show_archive", os.path.basename(self.podcast_file)
         )
 
     def tearDown(self) -> None:
@@ -39,14 +37,12 @@ class TestMoveFile(unittest.TestCase):
     def testDryRunArchive(self) -> None:
         args = [
             "--dry-run",
-            "--archive-folder",
-            self.archive,
-            "--podcast-show-name",
-            self.podcast_show_name,
+            "--archive-destination",
+            self.archived_podcast_path,
             "--file-path",
             self.podcast_file,
-            "--destination",
-            self.destination,
+            "--file-destination",
+            self.destination_podcast_path,
         ]
         move_file.main(args)
         self.assertTrue(os.path.isfile(self.podcast_file))
@@ -56,12 +52,10 @@ class TestMoveFile(unittest.TestCase):
     def testDryRunNoArchive(self) -> None:
         args = [
             "--dry-run",
-            "--podcast-show-name",
-            self.podcast_show_name,
             "--file-path",
             self.podcast_file,
-            "--destination",
-            self.destination,
+            "--file-destination",
+            self.destination_podcast_path,
         ]
         move_file.main(args)
         self.assertTrue(os.path.isfile(self.podcast_file))
@@ -70,14 +64,12 @@ class TestMoveFile(unittest.TestCase):
 
     def testProdRunArchive(self) -> None:
         args = [
-            "--archive-folder",
-            self.archive,
-            "--podcast-show-name",
-            self.podcast_show_name,
+            "--archive-destination",
+            self.archived_podcast_path,
             "--file-path",
             self.podcast_file,
-            "--destination",
-            self.destination,
+            "--file-destination",
+            self.destination_podcast_path,
         ]
         move_file.main(args)
         self.assertFalse(os.path.isfile(self.podcast_file))
@@ -86,12 +78,10 @@ class TestMoveFile(unittest.TestCase):
 
     def testProdRunNoArchive(self) -> None:
         args = [
-            "--podcast-show-name",
-            self.podcast_show_name,
             "--file-path",
             self.podcast_file,
-            "--destination",
-            self.destination,
+            "--file-destination",
+            self.destination_podcast_path,
         ]
         move_file.main(args)
         self.assertFalse(os.path.isfile(self.podcast_file))

--- a/prepare_for_phone.py
+++ b/prepare_for_phone.py
@@ -79,15 +79,18 @@ def ProcessAndMoveFilesOver(
         for file in files:
             q: queue.Queue[str] = queue.Queue()
             title_prefix = "%04d_" % (file.index) if file.index else ""
+            file_destination = pathlib.Path(destination, file.path.name)
             args = [
-                "--podcast-show-name=%s" % (file.podcast_show_name),
                 "--file-path=%s" % (file.path),
-                "--destination=%s" % destination,
+                "--file-destination=%s" % file_destination,
                 "--title-prefix=%s" % (title_prefix),
                 "--speed=%f" % (file.speed),
             ]
             if file.archive == archive.Archive.YES:
-                args += ["--archive-folder=%s" % (archive_folder)]
+                archive_destination = archive_folder.joinpath(
+                    file.podcast_show_name, file.path.name
+                )
+                args += ["--archive-destination=%s" % (archive_destination)]
             if dry_run:
                 args += ["--dry-run"]
             futures.append((file, q, executor.submit(work, q, args)))


### PR DESCRIPTION
podcast was only used to determine the complete archive path, but it's cleaner to have the caller compute the archive path and just pass it indirectly.

Also change destination to file_destination and pass in the full path to be consistent with how the file and archive location are passed in.