### PR TITLE
Add SetMetadata to audio_metadata

### DIFF
--- a/audio_metadata.py
+++ b/audio_metadata.py
@@ -75,6 +75,10 @@ def SetMetadata(
     title: typing.Optional[str] = None,
     album: typing.Optional[str] = None,
 ) -> None:
+    # If no values were provided, we can jsut return early.
+    if not title and not album:
+        return
+
     ext = file.suffix.lower()
     if ext == ".mp3":
         try:
@@ -89,6 +93,7 @@ def SetMetadata(
             tags[MP3_ID3_ALBUM_TAG] = TALB(encoding=3, text=album)  # type: ignore
 
         tags.save(file)
+
     elif ext == ".m4a":
         m4a_file = MP4(str(file))  # type: ignore
 
@@ -99,5 +104,6 @@ def SetMetadata(
             m4a_file[M4A_ALBUM_TAG] = album
 
         m4a_file.save()  # type: ignore
+
     else:
         raise FileTypeError("Unhandled filetype, path %s" % file)

--- a/audio_metadata_test.py
+++ b/audio_metadata_test.py
@@ -1,10 +1,36 @@
+import contextlib
 import pathlib
 import shutil
 import tempfile
+import types
+import typing
 import unittest
 
 import audio_metadata
 import test_utils
+
+
+class TestFileCopyContextManager(contextlib.AbstractContextManager[pathlib.Path]):
+    def __init__(self, test_file: str):
+        self.test_file = pathlib.Path(test_utils.TEST_DATA_DIR, test_file)
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.full_path = pathlib.Path(self.temp_directory.name, test_file)
+
+        shutil.copyfile(self.test_file, self.full_path)
+
+    def __del__(self) -> None:
+        self.temp_directory.cleanup()
+
+    def __enter__(self) -> pathlib.Path:
+        return self.full_path
+
+    def __exit__(
+        self,
+        exctype: typing.Optional[typing.Type[BaseException]],
+        excinst: typing.Optional[BaseException],
+        exctb: typing.Optional[types.TracebackType],
+    ) -> typing.Optional[bool]:
+        pass
 
 
 class TestAudioMetadata(unittest.TestCase):
@@ -75,104 +101,56 @@ class TestAudioMetadata(unittest.TestCase):
         )
 
     def testSetMetadata_MP3_AlbumAndTitle(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.mp3")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.MP3_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, "NEW_TITLE", "NEW_ALBUM")
 
             self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
             self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_MP3_OnlyTitle(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.mp3")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.MP3_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, title="NEW_TITLE")
 
             self.assertEqual("Test Data Album", audio_metadata.GetAlbum(full_path))
             self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_MP3_OnlyAlbum(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.mp3")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.MP3_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, album="NEW_ALBUM")
 
             self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
             self.assertEqual("Test MP3", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_MP3_NoValues(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.mp3")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.MP3_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path)
 
             self.assertEqual("Test Data Album", audio_metadata.GetAlbum(full_path))
             self.assertEqual("Test MP3", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_M4A_AlbumAndTitle(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.m4a")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.M4A_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, "NEW_TITLE", "NEW_ALBUM")
 
             self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
             self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_M4A_OnlyTitle(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.m4a")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.M4A_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, title="NEW_TITLE")
 
             self.assertEqual("m4a test album", audio_metadata.GetAlbum(full_path))
             self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_M4A_OnlyAlbum(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.m4a")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.M4A_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path, album="NEW_ALBUM")
 
             self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
             self.assertEqual("m4a test", audio_metadata.GetTitle(full_path))
 
     def testSetMetadata_M4A_NoValues(self) -> None:
-        with tempfile.TemporaryDirectory() as f:
-            full_path = pathlib.Path(f, "test.m4a")
-            shutil.copyfile(
-                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
-                full_path,
-            )
-
+        with TestFileCopyContextManager(test_utils.M4A_TEST_FILE) as full_path:
             audio_metadata.SetMetadata(full_path)
 
             self.assertEqual("m4a test album", audio_metadata.GetAlbum(full_path))

--- a/audio_metadata_test.py
+++ b/audio_metadata_test.py
@@ -1,4 +1,6 @@
 import pathlib
+import shutil
+import tempfile
 import unittest
 
 import audio_metadata
@@ -71,6 +73,118 @@ class TestAudioMetadata(unittest.TestCase):
             audio_metadata.NO_TITLE_FOUND,
             title,
         )
+
+    def testSetMetadata_MP3_AlbumAndTitle(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.mp3")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, "NEW_TITLE", "NEW_ALBUM")
+
+            self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_MP3_OnlyTitle(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.mp3")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, title="NEW_TITLE")
+
+            self.assertEqual("Test Data Album", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_MP3_OnlyAlbum(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.mp3")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, album="NEW_ALBUM")
+
+            self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("Test MP3", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_MP3_NoValues(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.mp3")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path)
+
+            self.assertEqual("Test Data Album", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("Test MP3", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_M4A_AlbumAndTitle(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.m4a")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, "NEW_TITLE", "NEW_ALBUM")
+
+            self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_M4A_OnlyTitle(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.m4a")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, title="NEW_TITLE")
+
+            self.assertEqual("m4a test album", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("NEW_TITLE", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_M4A_OnlyAlbum(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.m4a")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path, album="NEW_ALBUM")
+
+            self.assertEqual("NEW_ALBUM", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("m4a test", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_M4A_NoValues(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.m4a")
+            shutil.copyfile(
+                pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.M4A_TEST_FILE),
+                full_path,
+            )
+
+            audio_metadata.SetMetadata(full_path)
+
+            self.assertEqual("m4a test album", audio_metadata.GetAlbum(full_path))
+            self.assertEqual("m4a test", audio_metadata.GetTitle(full_path))
+
+    def testSetMetadata_InvalidFileType(self) -> None:
+        with tempfile.TemporaryDirectory() as f:
+            full_path = pathlib.Path(f, "test.txt")
+            full_path.touch()
+
+            with self.assertRaises(audio_metadata.FileTypeError):
+                audio_metadata.SetMetadata(full_path)
 
 
 if __name__ == "__main__":

--- a/audio_metadata_test.py
+++ b/audio_metadata_test.py
@@ -162,7 +162,7 @@ class TestAudioMetadata(unittest.TestCase):
             full_path.touch()
 
             with self.assertRaises(audio_metadata.FileTypeError):
-                audio_metadata.SetMetadata(full_path)
+                audio_metadata.SetMetadata(full_path, title="new_title")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows all the metadata related code in PrepareAudioAndMove to be moved to a better home.