### PR TITLE
Move file conversion code out of PrepareAudioAndMove into a new function

### DIFF
--- a/conversions.py
+++ b/conversions.py
@@ -1,7 +1,10 @@
+import math
 import os
 import pathlib
 
 import ffmpeg_helper
+
+LOUDNESS_TARGET = -10.0
 
 
 # TODO: Add tests, and make one function that just takes the pattern of files to convert.
@@ -23,3 +26,17 @@ def ConvertAllWEBMToMP3(folder: pathlib.Path) -> None:
             ffmpeg_helper.ConvertFile(file, file.with_suffix(".mp3"))
             # No need to keep the original file around now
             os.remove(file)
+
+
+def CreateAdjustedPodcastForPlayback(
+    input_file: pathlib.Path, output_file: pathlib.Path, speed: float
+) -> None:
+    stream = ffmpeg_helper.ffmpeg.input(str(input_file))
+    stream = ffmpeg_helper.ffmpeg.filter(
+        stream, filter_name="loudnorm", i=LOUDNESS_TARGET
+    )
+    if not math.isclose(1.0, speed):
+        stream = ffmpeg_helper.ffmpeg.filter(stream, filter_name="atempo", tempo=speed)
+
+    stream = ffmpeg_helper.ffmpeg.output(stream, str(output_file))
+    ffmpeg_helper.ffmpeg.run(stream, cmd=ffmpeg_helper.FFMPEG_EXE)


### PR DESCRIPTION
Move all the code related to converting the audio files into CreateAdjustedPodcastForPlayback.

Also slightly adjust the order of operations in PrepareAudioAndMove to avoid one file copy. Instead of "copy file, change metadata, create new file with conversions changed", we just have "create new file with conversion changes, adjust metadata"

Since the code in PrepareAudioAndMove is much smaller, we can also indent it and use a contextmanager to automatically close
the temporary directory it creates.

FIXES #8