### PR TITLE
Determine Title before starting subprocess to update audio files

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -7,16 +7,8 @@ import audio_metadata
 import conversions
 
 
-def _GenerateTitle(file: pathlib.Path, title_prefix: str) -> str:
-    current_title = audio_metadata.GetTitle(file)
-    if current_title:
-        return title_prefix + current_title
-
-    return title_prefix + os.path.basename(file)
-
-
 def PrepareAudioAndMove(
-    file: pathlib.Path, dest: pathlib.Path, album: str, title_prefix: str, speed: float
+    file: pathlib.Path, dest: pathlib.Path, title: str, album: str, speed: float
 ) -> None:
     print("Preparing Audio file %s" % file)
 
@@ -24,8 +16,7 @@ def PrepareAudioAndMove(
         working_copy = pathlib.Path(tmpdir, file.name)
         conversions.CreateAdjustedPodcastForPlayback(file, working_copy, speed)
 
-        new_title = _GenerateTitle(file, title_prefix)
-        audio_metadata.SetMetadata(working_copy, title=new_title, album=album)
+        audio_metadata.SetMetadata(working_copy, title=title, album=album)
 
         # We don't copy the file to the destination until all the processing is
         # done to prevent the output folder from having incomplete files, or

--- a/helper_test.py
+++ b/helper_test.py
@@ -22,14 +22,12 @@ class TestHelper(unittest.TestCase):
         )
 
         helper.PrepareAudioAndMove(
-            full_path, final_full_path, "podcast album", "title_prefix: ", 1.0
+            full_path, final_full_path, "new_title", "podcast album", 1.0
         )
         self.assertFalse(os.path.exists(full_path))
         self.assertTrue(os.path.exists(final_full_path))
+        self.assertEqual("new_title", audio_metadata.GetTitle(final_full_path))
         self.assertEqual("podcast album", audio_metadata.GetAlbum(final_full_path))
-        self.assertEqual(
-            "title_prefix: Test MP3", audio_metadata.GetTitle(final_full_path)
-        )
 
     def testListTitleAndAlbum(self) -> None:
         root = tempfile.mkdtemp()
@@ -44,15 +42,15 @@ class TestHelper(unittest.TestCase):
         )
 
         helper.PrepareAudioAndMove(
-            full_path, final_full_path, "podcast album", "title_prefix: ", 1.0
+            full_path, final_full_path, "new_title", "podcast album", 1.0
         )
         self.assertFalse(os.path.exists(full_path))
         self.assertTrue(os.path.exists(final_full_path))
-        self.assertEqual("podcast album", audio_metadata.GetAlbum(final_full_path))
         self.assertEqual(
-            "title_prefix: m4a test",
+            "new_title",
             audio_metadata.GetTitle(final_full_path),
         )
+        self.assertEqual("podcast album", audio_metadata.GetAlbum(final_full_path))
 
     def testListTitleAndAlbumAfterNoTitleOrAlbum(self) -> None:
         root = tempfile.mkdtemp()
@@ -67,15 +65,15 @@ class TestHelper(unittest.TestCase):
         )
 
         helper.PrepareAudioAndMove(
-            full_path, final_full_path, "podcast album", "title_prefix: ", 1.0
+            full_path, final_full_path, "new_title", "podcast album", 1.0
         )
         self.assertFalse(os.path.exists(full_path))
         self.assertTrue(os.path.exists(final_full_path))
-        self.assertEqual("podcast album", audio_metadata.GetAlbum(final_full_path))
         self.assertEqual(
-            "title_prefix: test.mp3",
+            "new_title",
             audio_metadata.GetTitle(final_full_path),
         )
+        self.assertEqual("podcast album", audio_metadata.GetAlbum(final_full_path))
 
 
 if __name__ == "__main__":

--- a/move_file.py
+++ b/move_file.py
@@ -28,18 +28,16 @@ def _ArchiveFile(
 def _UpdateFileandMoveOver(
     file_source: pathlib.Path,
     file_destination: pathlib.Path,
-    title_prefix: str,
+    title: str,
+    album: str,
     speed: float,
     dry_run: bool,
 ) -> None:
-    album = file_source.parent.name
     if dry_run:
         print("Dry run, would have moved %s to %s" % (file_source, file_destination))
         print("With album %s" % album)
     else:
-        helper.PrepareAudioAndMove(
-            file_source, file_destination, album, title_prefix, speed
-        )
+        helper.PrepareAudioAndMove(file_source, file_destination, title, album, speed)
 
 
 def main(args: typing.Optional[typing.List[str]]) -> None:
@@ -47,7 +45,8 @@ def main(args: typing.Optional[typing.List[str]]) -> None:
     parser.add_argument("--file-path", type=pathlib.Path, required=True)
     parser.add_argument("--file-destination", type=pathlib.Path, required=True)
     parser.add_argument("--archive-destination", type=pathlib.Path, default=None)
-    parser.add_argument("--title-prefix", type=str, default="")
+    parser.add_argument("--album", type=str, required=True)
+    parser.add_argument("--title", type=str, required=True)
     parser.add_argument("--speed", type=float, default=1.0)
     parser.add_argument("--dry-run", action="store_true", default=False)
     parsed_args = parser.parse_args(args)
@@ -59,7 +58,8 @@ def main(args: typing.Optional[typing.List[str]]) -> None:
     _UpdateFileandMoveOver(
         parsed_args.file_path,
         parsed_args.file_destination,
-        parsed_args.title_prefix,
+        parsed_args.title,
+        parsed_args.album,
         parsed_args.speed,
         parsed_args.dry_run,
     )

--- a/move_file_test.py
+++ b/move_file_test.py
@@ -1,8 +1,10 @@
 import os
+import pathlib
 import shutil
 import tempfile
 import unittest
 
+import audio_metadata
 import move_file
 import test_utils
 
@@ -11,23 +13,23 @@ class TestMoveFile(unittest.TestCase):
     def setUp(self) -> None:
         self.holding_dir = tempfile.TemporaryDirectory()
 
-        test_file_source = os.path.join(
+        test_file_source = pathlib.Path(
             test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE
         )
-        self.podcast_file = os.path.join(
+        self.podcast_file = pathlib.Path(
             self.holding_dir.name, test_utils.MP3_TEST_FILE
         )
         shutil.copyfile(test_file_source, self.podcast_file)
 
-        self.destination = os.path.join(self.holding_dir.name, "destination")
+        self.destination = pathlib.Path(self.holding_dir.name, "destination")
         os.makedirs(self.destination)
 
-        self.archive = os.path.join(self.holding_dir.name, "archive")
+        self.archive = pathlib.Path(self.holding_dir.name, "archive")
 
-        self.destination_podcast_path = os.path.join(
+        self.destination_podcast_path = pathlib.Path(
             self.destination, os.path.basename(self.podcast_file)
         )
-        self.archived_podcast_path = os.path.join(
+        self.archived_podcast_path = pathlib.Path(
             self.archive, "fake_show_archive", os.path.basename(self.podcast_file)
         )
 
@@ -38,11 +40,15 @@ class TestMoveFile(unittest.TestCase):
         args = [
             "--dry-run",
             "--archive-destination",
-            self.archived_podcast_path,
+            str(self.archived_podcast_path),
             "--file-path",
-            self.podcast_file,
+            str(self.podcast_file),
             "--file-destination",
-            self.destination_podcast_path,
+            str(self.destination_podcast_path),
+            "--title",
+            "new_title",
+            "--album",
+            "new_album",
         ]
         move_file.main(args)
         self.assertTrue(os.path.isfile(self.podcast_file))
@@ -53,9 +59,13 @@ class TestMoveFile(unittest.TestCase):
         args = [
             "--dry-run",
             "--file-path",
-            self.podcast_file,
+            str(self.podcast_file),
             "--file-destination",
-            self.destination_podcast_path,
+            str(self.destination_podcast_path),
+            "--title",
+            "new_title",
+            "--album",
+            "new_album",
         ]
         move_file.main(args)
         self.assertTrue(os.path.isfile(self.podcast_file))
@@ -65,28 +75,50 @@ class TestMoveFile(unittest.TestCase):
     def testProdRunArchive(self) -> None:
         args = [
             "--archive-destination",
-            self.archived_podcast_path,
+            str(self.archived_podcast_path),
             "--file-path",
-            self.podcast_file,
+            str(self.podcast_file),
             "--file-destination",
-            self.destination_podcast_path,
+            str(self.destination_podcast_path),
+            "--title",
+            "new_title",
+            "--album",
+            "new_album",
         ]
         move_file.main(args)
         self.assertFalse(os.path.isfile(self.podcast_file))
         self.assertTrue(os.path.isfile(self.destination_podcast_path))
         self.assertTrue(os.path.isfile(self.archived_podcast_path))
 
+        self.assertEqual(
+            "new_title", audio_metadata.GetTitle(self.destination_podcast_path)
+        )
+        self.assertEqual(
+            "new_album", audio_metadata.GetAlbum(self.destination_podcast_path)
+        )
+
     def testProdRunNoArchive(self) -> None:
         args = [
             "--file-path",
-            self.podcast_file,
+            str(self.podcast_file),
             "--file-destination",
-            self.destination_podcast_path,
+            str(self.destination_podcast_path),
+            "--title",
+            "new_title",
+            "--album",
+            "new_album",
         ]
         move_file.main(args)
         self.assertFalse(os.path.isfile(self.podcast_file))
         self.assertTrue(os.path.isfile(self.destination_podcast_path))
         self.assertFalse(os.path.isfile(self.archived_podcast_path))
+
+        self.assertEqual(
+            "new_title", audio_metadata.GetTitle(self.destination_podcast_path)
+        )
+        self.assertEqual(
+            "new_album", audio_metadata.GetAlbum(self.destination_podcast_path)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Move title generation to ProcessAndMoveFilesOver and pass in title and album.

This means the spawned process isn't making any decisions about the file value and instead is only worried about implementing them.