### PR TITLE
Remove old flag from flake8 run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,6 @@ repos:
     rev: 7.1.1
     hooks:
     -   id: flake8
-        # TODO: I think this is an old arg that can be deleted.
-        args: ["--extend-exclude=*_pb2.py"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
No need to ignore _pb2.py files in this repo since there aren't any.