### PR TITLE
Add Ruff and Start Enforcing Naming Conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,13 @@ repos:
     -   id: mypy
         args: ["--strict"]
         additional_dependencies: [mutagen==1.47.0]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.9
+  hooks:
+    # Only use ruff for pydocstyle comments for now.
+    # Consider using it to replace the other tooling later.
+    - id: ruff
+      args: [--fix]
 -   repo: local
     hooks:
     # TODO: Everything should be migrated out of this legacy precommit step.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.6.9
   hooks:
-    # Only use ruff for pydocstyle comments for now.
+    # Only use ruff for pep8-naming for now.
     # Consider using it to replace the other tooling later.
     - id: ruff
       args: [--fix]

--- a/podcast_database.py
+++ b/podcast_database.py
@@ -9,15 +9,15 @@ import time_helper
 import user_input
 
 
-class DatabaseLoadingException(Exception):
+class DatabaseLoadingError(Exception):
     pass
 
 
-class InvalidPodcastShowPath(Exception):
+class PodcastShowPathError(Exception):
     pass
 
 
-class InvalidPodcastEpisodePath(Exception):
+class PodcastEpisodePathError(Exception):
     pass
 
 
@@ -87,7 +87,7 @@ class PodcastDatabase(object):
                             podcast_folder, podcast_show.PRIORITY_SKIP
                         ).Load(f)
                     else:
-                        raise DatabaseLoadingException(
+                        raise DatabaseLoadingError(
                             "Failed to load %s." % (podcast_folder)
                         )
         return loaded
@@ -279,7 +279,7 @@ class PodcastDatabase(object):
         for show_name, episode_paths in specified_files.items():
             show = show_map.get(show_name.name)
             if not show:
-                raise InvalidPodcastShowPath(
+                raise PodcastShowPathError(
                     "Given show path, %s, doesn't exist" % show_name.name
                 )
 
@@ -289,7 +289,7 @@ class PodcastDatabase(object):
                 )
                 matching_episode = show.GetEpisode(full_potential_path)
                 if not matching_episode:
-                    raise InvalidPodcastEpisodePath(
+                    raise PodcastEpisodePathError(
                         "File, %s, doesn't exists for show %s"
                         % (episode_path, show_name.name)
                     )

--- a/podcast_database_test.py
+++ b/podcast_database_test.py
@@ -151,7 +151,7 @@ class TestPodcastDatabase(unittest.TestCase):
 
         # Now try to load the podcast database without this podcast and don't remove it.
         database = podcast_database.PodcastDatabase(self.root, [], False)
-        with self.assertRaises(podcast_database.DatabaseLoadingException):
+        with self.assertRaises(podcast_database.DatabaseLoadingError):
             database.Load(database_file, lambda x: "don't remove")
 
         database = podcast_database.PodcastDatabase(self.root, [], False)
@@ -514,7 +514,7 @@ class TestPodcastDatabase(unittest.TestCase):
             pathlib.Path("Fake_show"): [pathlib.Path(show_1_path, show_1_episodes[0])]
         }
 
-        with self.assertRaises(podcast_database.InvalidPodcastShowPath):
+        with self.assertRaises(podcast_database.PodcastShowPathError):
             database.GetSpecifiedFiles(files_to_get)
 
     def testGetSpecifiedFilesMissingEpisodes(self) -> None:
@@ -530,7 +530,7 @@ class TestPodcastDatabase(unittest.TestCase):
 
         files_to_get = {show_1_path: [pathlib.Path("fake_path")]}
 
-        with self.assertRaises(podcast_database.InvalidPodcastEpisodePath):
+        with self.assertRaises(podcast_database.PodcastEpisodePathError):
             database.GetSpecifiedFiles(files_to_get)
 
 

--- a/podcast_episode.py
+++ b/podcast_episode.py
@@ -7,7 +7,7 @@ import pyglet
 import time_helper
 
 
-class PodcastEpisodeLoadingException(Exception):
+class PodcastEpisodeLoadingError(Exception):
     pass
 
 
@@ -64,21 +64,21 @@ class PodcastEpisode(object):
         try:
             index = int(f.readline().strip())
         except ValueError as e:
-            raise PodcastEpisodeLoadingException(
+            raise PodcastEpisodeLoadingError(
                 "Failed to load index for episode, %s" % (e)
             )
 
         try:
             duration = int(f.readline())
         except ValueError as e:
-            raise PodcastEpisodeLoadingException(
+            raise PodcastEpisodeLoadingError(
                 "Failed to load duration for episode, %s" % (e)
             )
 
         try:
             modification_time = int(f.readline())
         except ValueError as e:
-            raise PodcastEpisodeLoadingException(
+            raise PodcastEpisodeLoadingError(
                 "Failed to load modification_time for episode, %s" % (e)
             )
 

--- a/podcast_episode_test.py
+++ b/podcast_episode_test.py
@@ -52,32 +52,32 @@ class TestPodcastEpisode(unittest.TestCase):
 
     def testPodcastEpisodeLoadBadData_OnlyPath(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testPodcastEpisodeLoadBadData_MissingDurationAndModification(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3\n66\n")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testPodcastEpisodeLoadBadData_MissingModification(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3\n66\n15\n")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testPodcastEpisodeLoadBadData_IndexNotInt(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3\nbad index\n15\n100\n")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testPodcastEpisodeLoadBadData_DurationNotInt(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3\n66\nbad duration\n100\n")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testPodcastEpisodeLoadBadData_ModificationNotInt(self) -> None:
         data = io.StringIO("c:\\podcast\\podcast.mp3\n66\n15\nbad modification\n")
-        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingException):
+        with self.assertRaises(podcast_episode.PodcastEpisodeLoadingError):
             podcast_episode.PodcastEpisode.Load(data)
 
     def testIsPodcastFile(self) -> None:

--- a/prepare_for_phone_test.py
+++ b/prepare_for_phone_test.py
@@ -545,7 +545,7 @@ class TestPrepareForPhone(unittest.TestCase):
         database = podcast_database.PodcastDatabase(self.root, podcast_shows, False)
         database.UpdatePodcasts(allow_prompt=False)
 
-        with self.assertRaises(podcast_database.InvalidPodcastEpisodePath):
+        with self.assertRaises(podcast_database.PodcastEpisodePathError):
             prepare_for_phone.GetBatchofPodcastFiles(
                 database,
                 datetime.timedelta(

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+[lint]
+select = ["N"]
+ignore = ["N802", "N806"]


### PR DESCRIPTION
Currently just fix Exception naming issues, ignoring N802 and N806 for now.