### PR TITLE
Update python to 3.13 and pyglet to 2.0.18

### DIFF
--- a/podcast.yml
+++ b/podcast.yml
@@ -7,4 +7,4 @@ dependencies:
     - ffmpeg-python==0.2.0
     - mutagen==1.47.0
     - pre-commit==3.8.0
-    - pyglet==2.0.10
+    - pyglet==2.0.18

--- a/podcast.yml
+++ b/podcast.yml
@@ -1,7 +1,7 @@
 name: podcast
 dependencies:
   - ffmpeg==4.2.2
-  - python==3.12.0
+  - python==3.13.0
   - pip
   - pip:
     - ffmpeg-python==0.2.0


### PR DESCRIPTION
This started as a python only update, but the old version of pyglet breaks in python 3.13 so I needed to update it as well.

If interested, the pyglet issue and fix can be found here: https://github.com/pyglet/pyglet/issues/1196