### PR TITLE
Move Arg Parsing to new command_args.py

### DIFF
--- a/command_args.py
+++ b/command_args.py
@@ -1,0 +1,22 @@
+import argparse
+import dataclasses
+import typing
+
+
+@dataclasses.dataclass
+class Args:
+    dry_run: bool = False
+    verbose: bool = False
+
+
+def parse_args(args: typing.Optional[typing.List[str]] = None) -> Args:
+    parser = argparse.ArgumentParser(
+        description="Prepare podcast episodes for phone", exit_on_error=False
+    )
+
+    for field in dataclasses.fields(Args):
+        assert field.type is bool, "Only bool args are currently supported"
+        default = field.default if field.default is not None else argparse.SUPPRESS
+        parser.add_argument(f"--{field.name}", action="store_true", default=default)
+
+    return parser.parse_args(args, namespace=Args())

--- a/command_args_test.py
+++ b/command_args_test.py
@@ -1,0 +1,26 @@
+import argparse
+import unittest
+
+import command_args
+
+
+class TestCommandsArgs(unittest.TestCase):
+    def test_no_args(self) -> None:
+        parsed_args = command_args.parse_args()
+        self.assertEqual(parsed_args, command_args.Args())
+
+    def test_set_verbose(self) -> None:
+        parsed_args = command_args.parse_args(["--verbose"])
+        self.assertTrue(parsed_args.verbose)
+
+    def test_set_dry_run(self) -> None:
+        parsed_args = command_args.parse_args(["--dry_run"])
+        self.assertTrue(parsed_args.dry_run)
+
+    def test_try_set_invalid_parameter(self) -> None:
+        with self.assertRaises(argparse.ArgumentError):
+            command_args.parse_args(["--fake-flag-name"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/prepare_for_phone.py
+++ b/prepare_for_phone.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import argparse
 import concurrent.futures
 import datetime
 import os
@@ -14,6 +13,7 @@ import android_phone
 import archive
 import audio_metadata
 import backup
+import command_args
 import full_podcast_episode
 import podcast_database
 import podcast_show
@@ -178,10 +178,7 @@ def get_batch_of_podcast_files(
 def main(
     args: typing.Optional[typing.List[str]], user_settings: settings.Settings
 ) -> None:
-    parser = argparse.ArgumentParser(description="Prepare podcast episodes for phone")
-    parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--verbose", action="store_true")
-    parsed_args = parser.parse_args(args)
+    parsed_args = command_args.parse_args(args)
 
     unknown_folders = find_unknown_folders(
         user_settings.podcast_folder, user_settings.podcasts


### PR DESCRIPTION
Create a new typed Arg class to ensure only valid arguments are referenced.