### PR TITLE
Update Settings to return time_of_podcasts_to_add as timedelta

### DIFF
--- a/prepare_for_phone.py
+++ b/prepare_for_phone.py
@@ -237,12 +237,9 @@ def main(
     # to start processing the files and only later realize the phone isn't connected.
     phone.connect_to_phone()
 
-    time_in_hours = datetime.timedelta(
-        hours=user_settings.time_of_podcasts_to_add_in_hours
-    )
     unprocessed_files = get_batch_of_podcast_files(
         database,
-        time_in_hours,
+        user_settings.time_of_podcasts_to_add,
         user_settings.num_oldest_episodes_to_add,
         user_settings.specified_files,
     )

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import pathlib
@@ -78,8 +79,11 @@ class Settings(object):
                 )
 
         self._NUM_OLDEST_EPISODES_TO_ADD = int(raw_json["NUM_OLDEST_EPISODES_TO_ADD"])
-        self._TIME_OF_PODCASTS_TO_ADD_IN_HOURS = int(
+        time_of_podcasts_to_add_in_hours = int(
             raw_json["TIME_OF_PODCASTS_TO_ADD_IN_HOURS"]
+        )
+        self._TIME_OF_PODCASTS_TO_ADD = datetime.timedelta(
+            hours=time_of_podcasts_to_add_in_hours
         )
 
         self._PODCASTS = podcasts
@@ -114,8 +118,8 @@ class Settings(object):
         return self._NUM_OLDEST_EPISODES_TO_ADD
 
     @property
-    def time_of_podcasts_to_add_in_hours(self) -> int:
-        return self._TIME_OF_PODCASTS_TO_ADD_IN_HOURS
+    def time_of_podcasts_to_add(self) -> datetime.timedelta:
+        return self._TIME_OF_PODCASTS_TO_ADD
 
     @property
     def podcasts(self) -> typing.List[podcast_show.PodcastShow]:

--- a/settings_test.py
+++ b/settings_test.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import pathlib
 import tempfile
@@ -43,7 +44,9 @@ class TestSettings(unittest.TestCase):
                 pathlib.Path("D:\\Podcasts\\On Phone"), user_settings.backup_folder
             )
             self.assertEqual(1, user_settings.num_oldest_episodes_to_add)
-            self.assertEqual(10, user_settings.time_of_podcasts_to_add_in_hours)
+            self.assertEqual(
+                datetime.timedelta(hours=10), user_settings.time_of_podcasts_to_add
+            )
 
     def test_settings_file_missing_key(self) -> None:
         for key in self._default_settings.keys():


### PR DESCRIPTION
Instead of returning the number of hours, the code returns a timedelta instead, which is what the callers really wanted to begin with.

No reason for the in code settings to be the same type as the value in the settings files.