### PR TITLE
Update process_and_move_files_over to validate destination and archive_folder are valid

### DIFF
--- a/prepare_for_phone.py
+++ b/prepare_for_phone.py
@@ -27,6 +27,14 @@ class UnknownPodcastFoldersError(Exception):
     pass
 
 
+class InvalidDestinationError(Exception):
+    pass
+
+
+class InvalidArchiveFolderError(Exception):
+    pass
+
+
 def find_unknown_folders(
     podcast_folder: pathlib.Path, expected_folders: typing.List[str]
 ) -> typing.List[pathlib.Path]:
@@ -91,6 +99,16 @@ def process_and_move_files_over(
     archive_folder: pathlib.Path,
     dry_run: bool,
 ) -> None:
+    if not destination.is_dir():
+        raise InvalidDestinationError(
+            f'Invalid destination folder passed into process_and_move_files_over. Expected a folder but "{destination}" isn\'t.'
+        )
+
+    if not archive_folder.is_dir():
+        raise InvalidArchiveFolderError(
+            f'Invalid archive folder passed into process_and_move_files_over. Expected a folder but "{archive_folder}" isn\'t.'
+        )
+
     # Limit the number of workers to less than the number of CPUs so I can still use the computer while converting.
     cpus_available = os.cpu_count() or 1
     max_workers = max(cpus_available - 2, 1)
@@ -258,10 +276,6 @@ def main(
     if not result:
         print("Done.")
         return
-
-    # TODO: Raise an exception if it exists and is a file?
-    if not user_settings.processed_file_boarding_zone_folder.exists():
-        os.mkdir(user_settings.processed_file_boarding_zone_folder)
 
     process_and_move_files_over(
         unprocessed_files,

--- a/prepare_for_phone_test.py
+++ b/prepare_for_phone_test.py
@@ -136,6 +136,26 @@ class TestPrepareForPhone(unittest.TestCase):
                 self.root, podcast_shows=podcast_shows
             )
 
+    def test_process_and_move_files_over_invalid_destination(self) -> None:
+        destination_folder = pathlib.Path(self.root, "destination")
+        archive_folder = pathlib.Path(self.root, "archive")
+        archive_folder.mkdir()
+
+        with self.assertRaises(prepare_for_phone.InvalidDestinationError):
+            prepare_for_phone.process_and_move_files_over(
+                [], destination_folder, archive_folder, True
+            )
+
+    def test_process_and_move_files_over_invalid_archive(self) -> None:
+        destination_folder = pathlib.Path(self.root, "destination")
+        destination_folder.mkdir()
+        archive_folder = pathlib.Path(self.root, "archive")
+
+        with self.assertRaises(prepare_for_phone.InvalidArchiveFolderError):
+            prepare_for_phone.process_and_move_files_over(
+                [], destination_folder, archive_folder, True
+            )
+
     def test_process_and_move_files_over(self) -> None:
         podcast_folder = pathlib.Path("podcast_show")
         podcast_test_show = self._create_podcast_show(

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,7 @@ class Settings(object):
         # If any of the required folders are missing, create them.
         self._ARCHIVE_FOLDER.mkdir(exist_ok=True)
         self._BACKUP_FOLDER.mkdir(exist_ok=True)
+        self._PROCESSED_FILE_BOARDING_ZONE_FOLDER.mkdir(exist_ok=True)
         self._USER_DATA_FOLDER.mkdir(exist_ok=True)
 
         self._PODCAST_DIRECTORY_ON_PHONE = pathlib.Path(

--- a/settings_test.py
+++ b/settings_test.py
@@ -8,17 +8,31 @@ import settings
 
 class TestSettings(unittest.TestCase):
     def setUp(self) -> None:
+        self._root_directory = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._root_directory.name)
+
+        self.podcast_folder = self.root.joinpath("Podcasts")
+        self.processed_file_boarding_zone_folder = self.root.joinpath("Add to Phone")
+        self.archive_folder = self.root.joinpath("Archive")
+        self.backup_folder = self.root.joinpath("Backup Folder")
+        self.user_data_folder = self.root.joinpath("User Data Folder")
+
         self._default_settings = {
             "ANDROID_PHONE_ID": "ABCD",
             "PODCAST_DIRECTORY_ON_PHONE": "/storage/emulated/0/Podcasts",
-            "PODCAST_FOLDER": "D:\\Podcasts",
-            "PROCESSED_FILE_BOARDING_ZONE_FOLDER": "D:\\Podcasts\\Add to Phone",
-            "ARCHIVE_FOLDER": "D:\\Podcasts\\Archive",
-            "BACKUP_FOLDER": "D:\\Podcasts\\On Phone",
+            "PODCAST_FOLDER": str(self.podcast_folder),
+            "PROCESSED_FILE_BOARDING_ZONE_FOLDER": str(
+                self.processed_file_boarding_zone_folder
+            ),
+            "ARCHIVE_FOLDER": str(self.archive_folder),
+            "BACKUP_FOLDER": str(self.backup_folder),
             "NUM_OLDEST_EPISODES_TO_ADD": 1,
             "TIME_OF_PODCASTS_TO_ADD_IN_HOURS": 10,
-            "USER_DATA_FOLDER": "E:\\podcast",
+            "USER_DATA_FOLDER": str(self.user_data_folder),
         }
+
+    def tearDown(self) -> None:
+        self._root_directory.cleanup()
 
     def test_load_valid_setting_files(self) -> None:
         with tempfile.NamedTemporaryFile(mode="w", delete_on_close=False) as f:
@@ -31,17 +45,13 @@ class TestSettings(unittest.TestCase):
                 pathlib.Path("/storage/emulated/0/Podcasts"),
                 user_settings.podcast_directory_on_phone,
             )
-            self.assertEqual(pathlib.Path("D:\\Podcasts"), user_settings.podcast_folder)
+            self.assertEqual(self.podcast_folder, user_settings.podcast_folder)
             self.assertEqual(
-                pathlib.Path("D:\\Podcasts\\Add to Phone"),
+                self.processed_file_boarding_zone_folder,
                 user_settings.processed_file_boarding_zone_folder,
             )
-            self.assertEqual(
-                pathlib.Path("D:\\Podcasts\\Archive"), user_settings.archive_folder
-            )
-            self.assertEqual(
-                pathlib.Path("D:\\Podcasts\\On Phone"), user_settings.backup_folder
-            )
+            self.assertEqual(self.archive_folder, user_settings.archive_folder)
+            self.assertEqual(self.backup_folder, user_settings.backup_folder)
             self.assertEqual(1, user_settings.num_oldest_episodes_to_add)
             self.assertEqual(10, user_settings.time_of_podcasts_to_add_in_hours)
 


### PR DESCRIPTION
If they aren't valid directories, the function will raise an expectation informing the user.

Settings is also updated to treat the holding folder similar to other required folders and it created it if it is missing.