### PR TITLE
Stop dry runs before moving files to Android

### DIFF
--- a/prepare_for_phone.py
+++ b/prepare_for_phone.py
@@ -297,6 +297,15 @@ def main(
         parsed_args.dry_run,
     )
 
+    # Currently dry_run isn't support past this point, so we stop early.
+    # https://github.com/seniorcodereviewbuddy/podcast/issues/55 looks
+    # at fixing this.
+    if parsed_args.dry_run:
+        print(
+            "Stopping now dry runs don't support interacting with android or the local backup"
+        )
+        return
+
     if phone.connect_to_phone():
         processed_files = [
             pathlib.Path(


### PR DESCRIPTION
It's not previously support and would crash when it happened.

Instead, exit early and add a TODO to support this in the future.