### PR TITLE
Enforce podcast_folder in Podcast show being an absolute path

### DIFF
--- a/e2e_test.py
+++ b/e2e_test.py
@@ -265,7 +265,6 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = []
 
-
         podcast_show_folder = self.podcast_folder.joinpath("show_1")
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P1),

--- a/e2e_test.py
+++ b/e2e_test.py
@@ -30,6 +30,9 @@ class TestE2E(unittest.TestCase):
     def setUp(self) -> None:
         self.root = tempfile.TemporaryDirectory()
 
+        self.podcast_folder = pathlib.Path(self.root.name, "Podcasts")
+        self.podcast_folder.mkdir()
+
         # Verify the emulator is ready and we can connect.
         self.assertTrue(android_phone.is_phone_connected(TestE2E.phone_emulator.id))
 
@@ -42,13 +45,13 @@ class TestE2E(unittest.TestCase):
         # handled in a better way.
         return [
             podcast_show.PodcastShow(
-                pathlib.Path("Add To Phone"), podcast_show.PRIORITY_SKIP
+                self.podcast_folder.joinpath("Add To Phone"), podcast_show.PRIORITY_SKIP
             ),
             podcast_show.PodcastShow(
-                pathlib.Path("Archive"), podcast_show.PRIORITY_SKIP
+                self.podcast_folder.joinpath("Archive"), podcast_show.PRIORITY_SKIP
             ),
             podcast_show.PodcastShow(
-                pathlib.Path("On Phone"), podcast_show.PRIORITY_SKIP
+                self.podcast_folder.joinpath("On Phone"), podcast_show.PRIORITY_SKIP
             ),
         ]
 
@@ -56,15 +59,14 @@ class TestE2E(unittest.TestCase):
         self,
         phone_id: str,
         android_podcast_folder: pathlib.Path,
-        computer_podcast_folder: pathlib.Path,
         podcasts: typing.Optional[list[podcast_show.PodcastShow]] = None,
         hours_to_add: int = 0,
     ) -> settings.Settings:
-        processed_folder = pathlib.Path(computer_podcast_folder, "Add To Phone")
+        processed_folder = self.podcast_folder.joinpath("Add To Phone")
 
-        archive_folder = pathlib.Path(computer_podcast_folder, "Archive")
+        archive_folder = self.podcast_folder.joinpath("Archive")
 
-        backup_folder = pathlib.Path(computer_podcast_folder, "On Phone")
+        backup_folder = self.podcast_folder.joinpath("On Phone")
 
         user_data_folder = pathlib.Path(self.root.name, "user_data")
 
@@ -73,7 +75,7 @@ class TestE2E(unittest.TestCase):
             "PODCAST_DIRECTORY_ON_PHONE": f"{android_podcast_folder}",
             "NUM_OLDEST_EPISODES_TO_ADD": 1,
             "TIME_OF_PODCASTS_TO_ADD_IN_HOURS": f"{hours_to_add}",
-            "PODCAST_FOLDER": f"{computer_podcast_folder}",
+            "PODCAST_FOLDER": f"{self.podcast_folder}",
             "PROCESSED_FILE_BOARDING_ZONE_FOLDER": f"{processed_folder}",
             "ARCHIVE_FOLDER": f"{archive_folder}",
             "BACKUP_FOLDER": f"{backup_folder}",
@@ -101,8 +103,7 @@ class TestE2E(unittest.TestCase):
         episodes_start_time: int = 1000,
         file_prefix: str = "",
     ) -> list[pathlib.Path]:
-        podcast_folder = pathlib.Path(self.root.name, podcast_dir)
-        podcast_folder.mkdir(exist_ok=True)
+        podcast_dir.mkdir(exist_ok=True)
 
         test_files = [
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
@@ -123,7 +124,7 @@ class TestE2E(unittest.TestCase):
         for x in range(num_episodes):
             test_file = test_files[x % len(test_files)]
             new_file_name = file_prefix + test_file.stem + str(x + 1) + test_file.suffix
-            copied_file = pathlib.Path(podcast_folder, new_file_name)
+            copied_file = podcast_dir.joinpath(new_file_name)
             show_files.append(copied_file)
 
             shutil.copyfile(
@@ -148,12 +149,9 @@ class TestE2E(unittest.TestCase):
         ]
 
         args: list[str] = []
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
         )
         prepare_for_phone.main(args, test_settings)
 
@@ -170,10 +168,7 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = ["--dry_run"]
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
-
-        podcast_show_folder = podcast_folder.joinpath("show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P1),
         ]
@@ -183,7 +178,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=0,
         )
@@ -220,10 +214,7 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = []
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
-
-        podcast_show_folder = podcast_folder.joinpath("show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P1),
         ]
@@ -233,7 +224,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=0,
         )
@@ -275,10 +265,8 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = []
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
 
-        podcast_show_folder = podcast_folder.joinpath("show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P1),
         ]
@@ -288,7 +276,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=0,
         )
@@ -325,9 +312,7 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = []
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
-        podcast_show_folder = podcast_folder.joinpath("show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P0),
         ]
@@ -337,7 +322,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=100,
         )
@@ -372,10 +356,7 @@ class TestE2E(unittest.TestCase):
             "Y",
         ] * times_to_run
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
-
-        podcast_show_folder = pathlib.Path(podcast_folder, "show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
         episodes = self._populate_podcast_show(podcast_show_folder)
 
         args: list[str] = []
@@ -386,7 +367,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=0,
         )
@@ -424,9 +404,7 @@ class TestE2E(unittest.TestCase):
 
         args: list[str] = []
 
-        podcast_folder = pathlib.Path(self.root.name, "Podcasts")
-        podcast_folder.mkdir()
-        podcast_show_folder = podcast_folder.joinpath("show_1")
+        podcast_show_folder = self.podcast_folder.joinpath("show_1")
 
         podcast_shows = [
             podcast_show.PodcastShow(podcast_show_folder, podcast_show.P0),
@@ -440,7 +418,6 @@ class TestE2E(unittest.TestCase):
         test_settings = self.create_test_settings(
             TestE2E.phone_emulator.id,
             TestE2E.phone_emulator.create_new_podcast_folder(),
-            podcast_folder,
             podcast_shows,
             hours_to_add=100,
         )

--- a/podcast_database_test.py
+++ b/podcast_database_test.py
@@ -61,9 +61,8 @@ class TestPodcastDatabase(unittest.TestCase):
         database.load(database_file)
 
     def test_save_and_load_basic(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        os.mkdir(podcast_folder)
+        known_folder = pathlib.Path(self.root, "known_folder")
+        known_folder.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
@@ -91,7 +90,7 @@ class TestPodcastDatabase(unittest.TestCase):
         episodes = ["podcast_1.mp3", "podcast_2.mp3", "podcast_élè.mp3"]
         now = 666
         for index, episode in enumerate(episodes):
-            full_path = pathlib.Path(podcast_folder, episode)
+            full_path = pathlib.Path(known_folder, episode)
             shutil.copyfile(
                 pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
                 full_path,
@@ -105,7 +104,7 @@ class TestPodcastDatabase(unittest.TestCase):
         contents = file_contents(database_file)
         want = "1\nknown_folder\nknown_folder\n4\n3\n"
         for index, episode in enumerate(episodes):
-            full_path = pathlib.Path(podcast_folder, episode)
+            full_path = pathlib.Path(known_folder, episode)
             want += "%s\n%d\n%d\n%d\n" % (
                 full_path,
                 index + 1,
@@ -117,16 +116,15 @@ class TestPodcastDatabase(unittest.TestCase):
         self.assertEqual(1, database.load(database_file))
 
         # Delete the folder and ensure we save nothing.
-        shutil.rmtree(podcast_folder)
+        shutil.rmtree(known_folder)
         database.update_podcasts()
 
         database.save(database_file)
         self.assertEqual("0\n", file_contents(database_file))
 
     def test_save_and_load_podcast_removed(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        os.mkdir(podcast_folder)
+        known_folder = pathlib.Path(self.root, "known_folder")
+        known_folder.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
@@ -163,9 +161,8 @@ class TestPodcastDatabase(unittest.TestCase):
         self.assertEqual("0\n", file_contents(database_file))
 
     def test_get_podcast_episodes_by_priority(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        os.mkdir(podcast_folder)
+        known_folder = pathlib.Path(self.root, "known_folder")
+        known_folder.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
@@ -175,7 +172,7 @@ class TestPodcastDatabase(unittest.TestCase):
         expected_selected_episodes = []
         now = 666
         for index, episode_name in enumerate(episodes_names):
-            full_path = pathlib.Path(podcast_folder, episode_name)
+            full_path = pathlib.Path(known_folder, episode_name)
             utime = now + 100 * index
 
             expected_selected_episodes.append(
@@ -225,7 +222,7 @@ class TestPodcastDatabase(unittest.TestCase):
         )
 
     def test_get_podcast_episodes_by_priority_test_ignore(self) -> None:
-        known_folder = pathlib.Path("known_folder")
+        known_folder = pathlib.Path(self.root, "known_folder")
         episodes = ["podcast_1.mp3", "podcast_2.mp3", "podcast_3.mp3"]
         show = self._create_podcast_show(known_folder, podcast_show.P1, episodes, 666)
         podcast_shows = [show]
@@ -263,9 +260,8 @@ class TestPodcastDatabase(unittest.TestCase):
         self.assertFalse(results)
 
     def test_get_oldest_files(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        os.mkdir(podcast_folder)
+        known_folder = pathlib.Path(self.root, "known_folder")
+        known_folder.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
@@ -274,7 +270,7 @@ class TestPodcastDatabase(unittest.TestCase):
         episodes = ["podcast_1.mp3", "podcast_2.mp3", "podcast_3.mp3"]
         now = 666
         for index, episode in enumerate(episodes):
-            full_path = pathlib.Path(podcast_folder, episode)
+            full_path = pathlib.Path(known_folder, episode)
             shutil.copyfile(
                 pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
                 full_path,
@@ -322,12 +318,10 @@ class TestPodcastDatabase(unittest.TestCase):
         self.assertEqual("podcast_3.mp3", os.path.basename(results[1].path))
 
     def test_get_oldest_files_from_multiple(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        known_folder_2 = pathlib.Path("known_folder_2")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        podcast_folder_2 = pathlib.Path(self.root, known_folder_2)
-        os.mkdir(podcast_folder)
-        os.mkdir(podcast_folder_2)
+        known_folder = pathlib.Path(self.root,"known_folder")
+        known_folder.mkdir()
+        known_folder_2 = pathlib.Path(self.root,"known_folder_2")
+        known_folder_2.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P2),
@@ -338,7 +332,7 @@ class TestPodcastDatabase(unittest.TestCase):
         for podcast_index, p in enumerate(podcast_shows):
             podcast_time = podcast_index * 1000 + now
             for episode_index, episode in enumerate(episodes):
-                full_path = pathlib.Path(self.root, p.podcast_folder, episode)
+                full_path = pathlib.Path(p.podcast_folder, episode)
                 shutil.copyfile(
                     pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
                     full_path,
@@ -355,12 +349,12 @@ class TestPodcastDatabase(unittest.TestCase):
         database.update_podcasts(allow_prompt=False)
 
         expected_episodes_by_age = [
-            pathlib.Path(self.root, known_folder, episodes[0]),
-            pathlib.Path(self.root, known_folder, episodes[1]),
-            pathlib.Path(self.root, known_folder, episodes[2]),
-            pathlib.Path(self.root, known_folder_2, episodes[0]),
-            pathlib.Path(self.root, known_folder_2, episodes[1]),
-            pathlib.Path(self.root, known_folder_2, episodes[2]),
+            pathlib.Path(known_folder, episodes[0]),
+            pathlib.Path(known_folder, episodes[1]),
+            pathlib.Path(known_folder, episodes[2]),
+            pathlib.Path(known_folder_2, episodes[0]),
+            pathlib.Path(known_folder_2, episodes[1]),
+            pathlib.Path(known_folder_2, episodes[2]),
         ]
 
         for i in range(1, len(expected_episodes_by_age) + 1):
@@ -370,21 +364,19 @@ class TestPodcastDatabase(unittest.TestCase):
                 self.assertEqual(expected_episodes_by_age[q], results[q].path)
 
     def test_repeated_path(self) -> None:
-        known_folder = pathlib.Path("repeated_folder")
+        known_folder = pathlib.Path(self.root, "repeated_folder")
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
         ]
         with self.assertRaises(Exception):
-            podcast_database.PodcastDatabase(pathlib.Path("root"), podcast_shows, False)
+            podcast_database.PodcastDatabase(self.root, podcast_shows, False)
 
     def test_stats(self) -> None:
-        known_folder = pathlib.Path("known_folder")
-        known_folder_2 = pathlib.Path("known_folder_2")
-        podcast_folder = pathlib.Path(self.root, known_folder)
-        podcast_folder_2 = pathlib.Path(self.root, known_folder_2)
-        os.mkdir(podcast_folder)
-        os.mkdir(podcast_folder_2)
+        known_folder = pathlib.Path(self.root, "known_folder")
+        known_folder.mkdir()
+        known_folder_2 = pathlib.Path(self.root, "known_folder_2")
+        known_folder_2.mkdir()
 
         podcast_shows = [
             podcast_show.PodcastShow(known_folder, podcast_show.P1),
@@ -392,27 +384,27 @@ class TestPodcastDatabase(unittest.TestCase):
         ]
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder, "podcast_1.mp3"),
+            pathlib.Path(known_folder, "podcast_1.mp3"),
         )
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder, "podcast_2.mp3"),
+            pathlib.Path(known_folder, "podcast_2.mp3"),
         )
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder, "podcast_3.mp3"),
+            pathlib.Path(known_folder, "podcast_3.mp3"),
         )
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder_2, "podcast_1.mp3"),
+            pathlib.Path(known_folder_2, "podcast_1.mp3"),
         )
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder_2, "podcast_2.mp3"),
+            pathlib.Path(known_folder_2, "podcast_2.mp3"),
         )
         shutil.copyfile(
             pathlib.Path(test_utils.TEST_DATA_DIR, test_utils.MP3_TEST_FILE),
-            pathlib.Path(podcast_folder_2, "podcast_3.mp3"),
+            pathlib.Path(known_folder_2, "podcast_3.mp3"),
         )
 
         database = podcast_database.PodcastDatabase(self.root, podcast_shows, False)

--- a/podcast_database_test.py
+++ b/podcast_database_test.py
@@ -318,9 +318,9 @@ class TestPodcastDatabase(unittest.TestCase):
         self.assertEqual("podcast_3.mp3", os.path.basename(results[1].path))
 
     def test_get_oldest_files_from_multiple(self) -> None:
-        known_folder = pathlib.Path(self.root,"known_folder")
+        known_folder = pathlib.Path(self.root, "known_folder")
         known_folder.mkdir()
-        known_folder_2 = pathlib.Path(self.root,"known_folder_2")
+        known_folder_2 = pathlib.Path(self.root, "known_folder_2")
         known_folder_2.mkdir()
 
         podcast_shows = [

--- a/podcast_show.py
+++ b/podcast_show.py
@@ -27,6 +27,7 @@ class PodcastShow(object):
             podcast_preprocessing_base.PreProcess_TypeAlias
         ] = None,
     ):
+        assert podcast_folder.is_absolute(), "podcast_folder must be an absolute path"
         self.podcast_folder = podcast_folder
         self.podcast_name = podcast_folder.name
         self.priority = priority
@@ -75,11 +76,11 @@ class PodcastShow(object):
         return self.podcast_folder >= other.podcast_folder
 
     def load(self, f: typing.TextIO) -> typing.Optional["PodcastShow"]:
-        loading_path = pathlib.Path(f.readline().strip())
-        if loading_path != self.podcast_folder:
+        loading_path = f.readline().strip()
+        if loading_path != self.podcast_folder.name:
             print(
                 "Attempted to load podcast %s into %s"
-                % (loading_path, self.podcast_folder)
+                % (loading_path, self.podcast_folder.name)
             )
             return None
 
@@ -96,7 +97,7 @@ class PodcastShow(object):
         return self
 
     def save(self, f: typing.TextIO) -> None:
-        f.write(str(self.podcast_folder) + "\n")
+        f.write(str(self.podcast_folder.name) + "\n")
         f.write(str(self.next_index) + "\n")
         f.write(str(len(self.episodes)) + "\n")
         for episode in self.episodes:

--- a/podcast_show_test.py
+++ b/podcast_show_test.py
@@ -87,7 +87,7 @@ class TestPodcast(unittest.TestCase):
         saved = io.StringIO()
         p.save(saved)
 
-        want = "%s\nNone\n0\n" % (podcast_folder)
+        want = "%s\nNone\n0\n" % (podcast_folder.name)
         self.assertEqual(want, saved.getvalue())
 
         p.load(io.StringIO(saved.getvalue()))
@@ -112,7 +112,7 @@ class TestPodcast(unittest.TestCase):
         p.save(saved)
 
         want = "%s\n2\n1\n%s\n1\n%d\n%d\n" % (
-            podcast_folder,
+            podcast_folder.name,
             podcast_file,
             test_utils.TEST_FILE_LENGTH_IN_SECONDS,
             now,
@@ -130,7 +130,7 @@ class TestPodcast(unittest.TestCase):
         saved = io.StringIO()
         p.save(saved)
 
-        want = "%s\n2\n0\n" % (podcast_folder)
+        want = "%s\n2\n0\n" % (podcast_folder.name)
         self.assertEqual(want, saved.getvalue())
 
         p.load(io.StringIO(saved.getvalue()))
@@ -155,13 +155,14 @@ class TestPodcast(unittest.TestCase):
             os.remove(pathlib.Path(folder, podcast_file))
 
         p = podcast_show.PodcastShow(
-            pathlib.Path("my_podcast"), podcast_show.P0, preprocess=clear_file
+            podcast_folder, podcast_show.P0, preprocess=clear_file
         )
         p.scan_for_updates(self.root)
         self.assertFalse(os.path.exists(podcast_file))
 
     def test_bad_load(self) -> None:
-        p = podcast_show.PodcastShow(pathlib.Path("my_podcast"), podcast_show.P0)
+        podcast_folder = pathlib.Path(self.root, "my_podcast")
+        p = podcast_show.PodcastShow(podcast_folder, podcast_show.P0)
         self.assertIsNone(p.load(io.StringIO("bad_podcast\n0\n")))
 
     def test_get_episode_present(self) -> None:


### PR DESCRIPTION
In order to keep backwards comptability, the save and load functions just use the name of the podcast folders, intead of the full paths.